### PR TITLE
Initial work building parsers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ When run from your project root directory, it runs the default `rake` task, capt
 
 If a tool's reporting cannot be found in the `rake` output parsed by Rerake, the corresponding report line will be silently omitted.
 
-Very early versions of this tool included support for [Cane](https://github.com/square/cane). I've removed it as its capabilities are (apparently) made redundant by other tools, and because testing (of version 2.6.2) yielded numerous apparent false negatives. It is no longer a dependency of this Gem or application.
+Very early versions of this tool included support for [Cane](https://github.com/square/cane). I've removed it as its capabilities are (apparently) made redundant by other tools, and because testing (of version 2.6.2) yielded numerous apparent false negatives. It is no longer a development dependency of this Gem or application.
 
 ## Installation
 
@@ -45,6 +45,10 @@ If, on the other hand, you've installed it as the regular command-line tool, the
     $ rerake
 
 as you would any other command.
+
+### On Dependencies
+
+The various tools supported by `rerake` are listed as *development* dependencies because *your* default Rake task might not include all of them. `Rerake` doesn't assume that you're running different tools, or that you're doing things in a different order. It should be able to find the output of any supported tool that's included as part of your default Rake task (what's run when you enter `bundle exec rake` at the command line).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ If, on the other hand, you've installed it into your system Gem repository, then
 
 as you would any other command.
 
+### Notes on Tool Usage
+
+* Cane produces *no output* unless it detects violations; hence, there is no way to tell by inspecting the output from `bundle exec rake` whether or not Cane is actually installed in the application being inspected.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment. Run `bundle exec rerake` to use the gem in this directory, ignoring other installed copies of this gem.

--- a/README.md
+++ b/README.md
@@ -12,14 +12,15 @@ When run from your project root directory, it runs the default `rake` task, capt
 1. RuboCop results (number of files inspected and number of offences found);
 1. Flay total score;
 1. Flog result &mdash; total score, method average, and method high score (with name of method);
-1. Reek total number of warnings;
-1. Cane total number of violations.
+1. Reek total number of warnings.
 
 If a tool's reporting cannot be found in the `rake` output parsed by Rerake, the corresponding report line will be silently omitted.
 
+Very early versions of this tool included support for [Cane](https://github.com/square/cane). I've removed it as its capabilities are (apparently) made redundant by other tools, and because testing (of version 2.6.2) yielded numerous apparent false negatives. It is no longer a dependency of this Gem or application.
+
 ## Installation
 
-Add this line to your application's Gemfile:
+Add this line to your application's Gemfile to use the API:
 
 ```ruby
 gem 'rerake'
@@ -29,7 +30,7 @@ And then execute:
 
     $ bundle
 
-Or install it yourself as:
+Or install the command-line tool as well as the API as:
 
     $ gem install rerake
 
@@ -39,15 +40,11 @@ If installed using your application's `Gemfile`, then run
 
     $ bundle exec rerake
 
-If, on the other hand, you've installed it into your system Gem repository, then run
+If, on the other hand, you've installed it as the regular command-line tool, then run
 
     $ rerake
 
 as you would any other command.
-
-### Notes on Tool Usage
-
-* Cane produces *no output* unless it detects violations; hence, there is no way to tell by inspecting the output from `bundle exec rake` whether or not Cane is actually installed in the application being inspected.
 
 ## Development
 
@@ -63,4 +60,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/jdicke
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,6 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
 
-require 'cane/rake_task'
 require 'rake/tasklib'
 require 'rake/testtask'
 require 'flay_task'
@@ -44,15 +43,9 @@ FlogTask.new do |t|
   t.dirs = %w(lib) # Look, Ma! No tests! (Run for `test` periodically.)
 end
 
-Cane::RakeTask.new do |t|
-  t.abc_max = 8
-  t.abc_glob = '{lib}/**/*.rb'
-  t.style_glob = '{lib,test}/**/*.rb'
-end
-
 # Coveralls not set up yet
 # require 'coveralls/rake/task'
 # Coveralls::RakeTask.new
 
 task(:default).clear
-task default: [:test, :rubocop, :flay, :flog, :reek, :cane]
+task default: [:test, :rubocop, :flay, :flog, :reek]

--- a/Rakefile
+++ b/Rakefile
@@ -39,7 +39,7 @@ end
 
 FlogTask.new do |t|
   t.verbose = true
-  t.threshold = 220 # default is 200
+  t.threshold = 250 # default is 200
   t.instance_variable_set :@methods_only, true
   t.dirs = %w(lib) # Look, Ma! No tests! (Run for `test` periodically.)
 end

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,7 @@ require 'rake/testtask'
 require 'flay_task'
 require 'flog'
 require 'flog_task'
+require 'inch/rake'
 require 'reek/rake/task'
 require 'rubocop/rake_task'
 
@@ -43,9 +44,11 @@ FlogTask.new do |t|
   t.dirs = %w(lib) # Look, Ma! No tests! (Run for `test` periodically.)
 end
 
+Inch::Rake::Suggest.new
+
 # Coveralls not set up yet
 # require 'coveralls/rake/task'
 # Coveralls::RakeTask.new
 
 task(:default).clear
-task default: [:test, :rubocop, :flay, :flog, :reek]
+task default: [:test, :rubocop, :flay, :flog, :reek, :inch]

--- a/Rakefile
+++ b/Rakefile
@@ -39,7 +39,7 @@ end
 
 FlogTask.new do |t|
   t.verbose = true
-  t.threshold = 200 # default is 200
+  t.threshold = 220 # default is 200
   t.instance_variable_set :@methods_only, true
   t.dirs = %w(lib) # Look, Ma! No tests! (Run for `test` periodically.)
 end

--- a/Rakefile
+++ b/Rakefile
@@ -39,7 +39,7 @@ end
 
 FlogTask.new do |t|
   t.verbose = true
-  t.threshold = 250 # default is 200
+  t.threshold = 300 # default is 200
   t.instance_variable_set :@methods_only, true
   t.dirs = %w(lib) # Look, Ma! No tests! (Run for `test` periodically.)
 end

--- a/lib/rerake.rb
+++ b/lib/rerake.rb
@@ -1,4 +1,7 @@
+
 require "rerake/version"
+
+require 'rerake/command_output'
 
 # Main containing module for Rerake, a Rake output-parsing and -reporting tool.
 module Rerake

--- a/lib/rerake.rb
+++ b/lib/rerake.rb
@@ -6,8 +6,12 @@ require 'rerake/command_output'
 # Main containing module for Rerake, a Rake output-parsing and -reporting tool.
 module Rerake
   def self.call
-    print 'Running Rake...'
-    puts 'done.'
-    puts "Parsers would do their thing here."
+    # print 'Running Rake...'
+    cmdline = ENV['RERAKE_COMMAND'] || 'bundle exec rake'
+    cmd = CommandOutput.new cmdline
+    # output_lines = cmd.output
+    # puts 'done.'
+    # puts "Parsers would do their thing here."
+    cmd
   end
 end

--- a/lib/rerake/command_output.rb
+++ b/lib/rerake/command_output.rb
@@ -1,0 +1,35 @@
+
+require 'open3'
+
+module Rerake
+  # Parse stdout and stderr from a command run via `Open3.capture3`.
+  class CommandOutput
+    # Internal methods that neither depend on nor affect instance state.
+    module Internals
+      def self.run_command(cmd_line)
+        Open3.capture3 cmd_line
+      end
+
+      def self.split_lines(buffer)
+        buffer.split "\n"
+      end
+    end
+    private_constant :Internals
+
+    attr_reader :errors, :output, :status
+
+    def initialize(cmd_line)
+      output, errors, status = Internals.run_command cmd_line
+      parse_results_from output, errors, status
+    end
+
+    private
+
+    def parse_results_from(output, errors, status)
+      @output = Internals.split_lines output
+      @errors = Internals.split_lines errors
+      @status = status
+      self
+    end
+  end # class Rerake::CommandOutput
+end

--- a/lib/rerake/parser/flay.rb
+++ b/lib/rerake/parser/flay.rb
@@ -1,0 +1,65 @@
+
+module Rerake
+  module Parser
+    # Parses Flay statistics reported with test output.
+    class Flay
+      # Internal methods not affecting or depending on instance state.
+      module Internals
+        def self.matcher
+          /Total score \(lower is better\) = (\d+)/
+        end
+      end
+      private_constant :Internals
+
+      attr_reader :counts
+
+      def initialize(report_lines)
+        @report_lines = report_lines
+        @counts = initial_counts
+        self
+      end
+
+      def parse
+        return self unless detail_line
+        assign_counts
+        self
+      end
+
+      private
+
+      attr_reader :report_lines
+
+      def assign_counts
+        values.each_with_index do |value, index|
+          @counts[indexes[index].to_sym] = value
+        end
+      end
+
+      def captures
+        detail_line.match(Internals.matcher).captures
+      end
+
+      def detail_line
+        @detail_line ||= Array(report_lines).grep(Internals.matcher).first
+      end
+
+      def detail_line_part_strings
+        ['total_score']
+      end
+
+      def indexes
+        detail_line_part_strings.map(&:to_sym)
+      end
+
+      def initial_counts
+        ret = Struct.new(*indexes).new
+        indexes.each { |index| ret[index] = 0 }
+        ret
+      end
+
+      def values
+        captures.map(&:to_i)
+      end
+    end # class Rerake::Parser::Flay
+  end
+end

--- a/lib/rerake/parser/flog.rb
+++ b/lib/rerake/parser/flog.rb
@@ -57,7 +57,7 @@ module Rerake
       class Scores
         # Internal methods that neither depend on nor modiify instance state.
         module Internals
-          def self.first_part_of_line(line)
+          def self._first_part_of_line(line)
             parts = line.split(':')
             return '0.0' if parts.count == 1
             parts.first
@@ -68,7 +68,7 @@ module Rerake
           end
 
           def self.value_from(line)
-            Float(first_part_of_line line)
+            Float(_first_part_of_line line)
           end
 
           def self.values
@@ -112,6 +112,10 @@ module Rerake
           self
         end
       end # class Rerake::Parser::Flog::Scores
+
+      ##################### ############################## #####################
+      ##################### ### Flog class code below. ### #####################
+      ##################### ############################## #####################
 
       # Internal methods that neither depend on nor affect instance state.
       module Internals

--- a/lib/rerake/parser/flog.rb
+++ b/lib/rerake/parser/flog.rb
@@ -1,0 +1,158 @@
+
+module Rerake
+  module Parser
+    # Parses Flog statistics reported with test output.
+    #
+    # Parsing Flog output is different than parsing almost any other tool's
+    # output, in that there is a *series* of significant lines. An example
+    # follows:
+    #   160.1: flog total
+    #     4.6: flog/method average
+    #
+    #     8.6: Foo::Bar::Baz#values   lib/foo/bar/baz.rb:58
+    #     8.1: Foo::Bar::Quux#values  lib/foo/bar/quux.rb:50
+    #     7.9: Foo::Bar::Quux#matcher lib/foo/bar/quux.rb:35
+    #     ...: ...more follows...
+    #
+    # Note that the blank line after "flog/method average" is included in the
+    # original output. So, instead of parsing multiple values out of a single
+    # line of output, we instead care about *four* lines, three of which provide
+    # score details (total, method average, and maximum score and method name).
+    # This means, again, that we can't use the generalised parse-a-detail-line
+    # approach as in other parsers.
+    class Flog
+      # Filters Flog report lines from report lines.
+      class DetailLines
+        # Internal methods that neither affect nor depend on instance state.
+        module Internals
+          def self.apply_filter(chunk)
+            chunk.delete_if { |item| item.strip.empty? }
+          end
+
+          def self.detail_chunk_from(report_lines)
+            report_lines.slice_before(/^ +?(\d+\.\d): flog total/).to_a[1]
+          end
+
+          def self.details_from(chunk)
+            select_lines(apply_filter(chunk))
+          end
+
+          def self.select_lines(input)
+            input[0..2]
+          end
+        end
+        private_constant :Internals
+
+        def initialize(report_lines)
+          @chunk = Internals.detail_chunk_from report_lines
+          self
+        end
+
+        def lines
+          Internals.details_from @chunk
+        end
+      end # class Rerake::Parser::Flog::DetailLines
+
+      # Parse floating-point score values from Flog output in report
+      class Scores
+        # Internal methods that neither depend on nor modiify instance state.
+        module Internals
+          def self.first_part_of_line(line)
+            parts = line.split(':')
+            return '0.0' if parts.count == 1
+            parts.first
+          end
+
+          def self.method_from(line)
+            line.split[1]
+          end
+
+          def self.value_from(line)
+            Float(first_part_of_line line)
+          end
+
+          def self.values
+            Struct.new(*Scores.names).new
+          end
+        end
+        private_constant :Internals
+
+        def initialize(detail_lines)
+          @counts = Internals.values
+          @detail_lines = detail_lines
+          self
+        end
+
+        def self.names
+          [:max_name, :max_score, :method_average, :total]
+        end
+
+        def to_h
+          parse
+          @counts.to_h
+        end
+
+        private
+
+        def parse
+          set_numeric_values
+          @counts[:max_name] = Internals.method_from @detail_lines[2]
+          self
+        end
+
+        def set_numeric_values
+          [:total, :method_average, :max_score].each_with_index do |key, index|
+            set_value key, index
+          end
+        end
+
+        def set_value(key, index)
+          value = Internals.value_from(@detail_lines[index])
+          @counts[key] = value
+          self
+        end
+      end # class Rerake::Parser::Flog::Scores
+
+      # Internal methods that neither depend on nor affect instance state.
+      module Internals
+        def self.init_counts
+          _clear_values(_init_struct)
+        end
+
+        def self._clear_values(values)
+          new_values = {}
+          values.members.each { |index| new_values[index] = 0 }
+          new_values
+        end
+
+        def self._init_struct
+          Struct.new(*Scores.names).new
+        end
+      end
+      private_constant :Internals
+
+      attr_reader :counts
+
+      def initialize(report_lines)
+        @report_lines = report_lines
+        @counts = Internals.init_counts
+        self
+      end
+
+      def parse
+        @counts = scores.to_h
+        self
+      end
+
+      private
+
+      def detail_lines
+        DetailLines.new(@report_lines).lines
+      end
+
+      def scores
+        Scores.new detail_lines
+      end
+    end # class Rerake::Parser::Flog
+  end
+end

--- a/lib/rerake/parser/mini_test.rb
+++ b/lib/rerake/parser/mini_test.rb
@@ -1,6 +1,4 @@
 
-require 'pry-byebug'
-
 module Rerake
   module Parser
     # Parses MiniTest (Spec/Unit) output, storing reported count values.

--- a/lib/rerake/parser/mini_test.rb
+++ b/lib/rerake/parser/mini_test.rb
@@ -1,0 +1,58 @@
+
+require 'pry-byebug'
+
+module Rerake
+  module Parser
+    # Parses MiniTest (Spec/Unit) output, storing reported count values.
+    class MiniTest
+      attr_reader :counts
+
+      def initialize(report_lines)
+        @report_lines = report_lines
+        @counts = {}
+        indexes.each { |index| @counts[index] = 0 }
+        self
+      end
+
+      def parse
+        return self unless detail_line
+        assign_counts
+        self
+      end
+
+      private
+
+      attr_reader :report_lines
+
+      def assign_counts
+        values.each_with_index do |value, index|
+          @counts[indexes[index]] = value
+        end
+      end
+
+      def detail_line
+        @detail_line ||= Array(report_lines).grep(matcher).first
+      end
+
+      def matcher
+        pattern_str = detail_line_part_strings.map do |what|
+          '(\d+?) ' + what
+        end.join(', ')[0..-2]
+        Regexp.new pattern_str
+      end
+
+      def detail_line_part_strings
+        ['tests', 'assertions', 'failures', 'errors', 'skips']
+      end
+
+      def indexes
+        detail_line_part_strings.map(&:to_sym)
+      end
+
+      def values
+        match_data = detail_line.match matcher
+        match_data.captures.map(&:to_i)
+      end
+    end # class Rerake::Parser::MiniTest
+  end
+end

--- a/lib/rerake/parser/mini_test/counts.rb
+++ b/lib/rerake/parser/mini_test/counts.rb
@@ -1,0 +1,52 @@
+
+module Rerake
+  module Parser
+    # Parses MiniTest (Spec/Unit) output, storing reported count values.
+    class MiniTest
+      # Wraps the various counters for the MiniTest parser.
+      class Counts
+        # Internal methods that neither affect nor depend on instance state.
+        module Internals
+          def self.captures_as_ints(captures)
+            captures.map(&:to_i)
+          end
+        end
+        private_constant :Internals
+
+        extend Forwardable
+
+        def initialize(keys)
+          @value = Struct.new(*keys).new
+          @value.members.each { |key| @value[key] = 0 }
+          self
+        end
+
+        def assign_from(captures)
+          each_capture_with_index(captures) do |value, index|
+            @value[@value.members[index]] = value
+          end
+        end
+
+        def to_hash
+          @value.to_h
+        end
+
+        def to_s
+          to_hash.to_h.to_s
+        end
+
+        def_delegator :to_hash, :values
+        def_delegator :to_hash, :[]
+
+        private
+
+        # This method smells of :reek:UtilityFunction
+        def each_capture_with_index(captures)
+          Internals.captures_as_ints(captures).each_with_index do |value, index|
+            yield value, index
+          end
+        end
+      end # class Rerake::Parser::MiniTest::Counts
+    end # class Rerake::Parser::MiniTest
+  end
+end

--- a/lib/rerake/parser/mini_test/counts.rb
+++ b/lib/rerake/parser/mini_test/counts.rb
@@ -7,7 +7,23 @@ module Rerake
       class Counts
         # Internal methods that neither affect nor depend on instance state.
         module Internals
-          def self.captures_as_ints(captures)
+          # Iterates an indexed array of MatchData captures converted to ints.
+          #
+          # Yields the (integer) value and capture index to a block.
+          #
+          # @param captures [Array] Captured data from parsing text w/regexp.
+          # @return [Array] Array of integer values converted from captures.
+          def self.each_capture_with_index(captures)
+            _as_ints(captures).each_with_index do |value, index|
+              yield value, index
+            end
+          end
+
+          # Returns an array of integers mapping string values passed in.
+          #
+          # @param captures [Array] Array of MatchData capture strings.
+          # @return [Array] Result from converting @param to integers.
+          def self._as_ints(captures)
             captures.map(&:to_i)
           end
         end
@@ -15,37 +31,59 @@ module Rerake
 
         extend Forwardable
 
+        # Given an array of keys, creates a Struct for tagged totals.
+        #
+        # The only halfway tricky bit is initialising values to zero rather than
+        # `nil`. This is done to guarantee that values returned will always be
+        # numeric, rather than requiring a call to `#to_i` to convert.
+        #
+        # @param keys [Array] Array of symbols to be used as Struct keys.
+        # @return [Counts] Returns this instance.
         def initialize(keys)
           @value = Struct.new(*keys).new
           @value.members.each { |key| @value[key] = 0 }
           self
         end
 
+        # Assigns captured data (from command output) to Struct values.
+        #
+        # Maps integer values from (numeric-indexed) capture data to (Symbol-
+        # indexed) internal Struct values. This is what will blow up if our data
+        # is somehow invalid; that's a feature exposing our bug. :grinning:
+        #
+        # @param captures [Array] Strings matched by a regex capture somewhere.
+        # @return [Counts] Returns this instance.
         def assign_from(captures)
-          each_capture_with_index(captures) do |value, index|
+          Internals.each_capture_with_index(captures) do |value, index|
             @value[@value.members[index]] = value
           end
+          self
         end
 
+        # Return the internal value object as a Hash instance
+        #
+        # Keys will be as specified to `#initialize`; values for matching keys
+        # as supplied to `#assign_from`. Any unassigned values will be returned
+        # as zero (see `#initialize` logic).
+        #
+        # @return [Hash] (Mutable) Hash with capture values (as integers).
         def to_hash
           @value.to_h
         end
 
+        # Return a string representation of the internal value object.
+        #
+        # After converting to a Hash, return its string representation. This is
+        # to avoid dump output like
+        # `#<Rerake::Parser::MiniTest::Counts:0x007fd74e469010>`.
+        #
+        # @return [String] As described above.
         def to_s
           to_hash.to_h.to_s
         end
 
         def_delegator :to_hash, :values
         def_delegator :to_hash, :[]
-
-        private
-
-        # This method smells of :reek:UtilityFunction
-        def each_capture_with_index(captures)
-          Internals.captures_as_ints(captures).each_with_index do |value, index|
-            yield value, index
-          end
-        end
       end # class Rerake::Parser::MiniTest::Counts
     end # class Rerake::Parser::MiniTest
   end

--- a/lib/rerake/parser/mini_test/matcher.rb
+++ b/lib/rerake/parser/mini_test/matcher.rb
@@ -1,0 +1,42 @@
+
+module Rerake
+  module Parser
+    # Parses MiniTest (Spec/Unit) output, storing reported count values.
+    class MiniTest
+      # Builds regexp matcher and index keys for MiniTest parser.
+      class Matcher
+        # Internal methods that neither affect nor depend on instance state.
+        module Internals
+          def self.indexes
+            _detail_line_part_strings.map(&:to_sym)
+          end
+
+          def self.pattern_str
+            _parts.join(', ')
+          end
+
+          def self._detail_line_part_strings
+            ['tests', 'assertions', 'failures', 'errors', 'skips']
+          end
+
+          def self._parts
+            _detail_line_part_strings.map { |what| '(\d+) ' + what }
+          end
+        end
+
+        def initialize
+          self
+        end
+
+        # This method smells of :reek:UtilityFunction
+        def to_regexp
+          Regexp.new(Internals.pattern_str)
+        end
+
+        def self.indexes
+          Internals.indexes
+        end
+      end # class Rerake::Parser::MiniTest::Matcher
+    end # class Rerake::Parser::MiniTest
+  end
+end

--- a/lib/rerake/parser/reek.rb
+++ b/lib/rerake/parser/reek.rb
@@ -1,0 +1,53 @@
+
+module Rerake
+  module Parser
+    # Parses Reek statistics reported with test output.
+    class Reek
+      # Internal methods not affecting or depending on instance state.
+      module Internals
+        def self.count_from(detail_line)
+          _first_capture(detail_line.match _matcher).to_i
+        end
+
+        def self.first_match_from(report_lines)
+          Array(report_lines).grep(_matcher).first
+        end
+
+        def self._first_capture(match_data)
+          match_data.captures.first
+        end
+
+        def self._matcher
+          /(\d+) total warning/
+        end
+      end
+      private_constant :Internals
+
+      attr_reader :counts
+
+      def initialize(report_lines)
+        @report_lines = report_lines
+        @counts = { warnings: 0 }
+        self
+      end
+
+      def parse
+        return self unless detail_line
+        assign_counts
+        self
+      end
+
+      private
+
+      attr_reader :report_lines
+
+      def assign_counts
+        @counts[:warnings] = Internals.count_from detail_line
+      end
+
+      def detail_line
+        @detail_line ||= Internals.first_match_from(report_lines)
+      end
+    end # class Rerake::Parser::Reek
+  end
+end

--- a/lib/rerake/parser/reek.rb
+++ b/lib/rerake/parser/reek.rb
@@ -18,7 +18,7 @@ module Rerake
         end
 
         def self._matcher
-          /(\d+) total warning/
+          /^(\d+) total warning/
         end
       end
       private_constant :Internals

--- a/lib/rerake/parser/reek.rb
+++ b/lib/rerake/parser/reek.rb
@@ -1,22 +1,45 @@
 
 module Rerake
+  # Contains parser classes for each supported tool; here, Reek.
   module Parser
     # Parses Reek statistics reported with test output.
     class Reek
       # Internal methods not affecting or depending on instance state.
       module Internals
+        # Returns the count of total warnings from a detail line.
+        #
+        # The "detail line" is (assumed to be) a single line from the output of
+        # running one or more Rake tasks. If the parameter does not match the
+        # format of a Reek total-warning-count line, this method returns `nil`.
+        #
+        # @param detail_line [String] Text line, possibly matching Reek output.
+        # @return [Fixnum, nil] First Regexp captured item, as integer.
         def self.count_from(detail_line)
           _first_capture(detail_line.match _matcher).to_i
         end
 
+        # Returns the first matching line from an Array of input lines.
+        #
+        # If what's passed in is a *single* line, it's wrapped in an Array
+        # before searching for a pattern match.
+        #
+        # @param report_lines [Array] Presumably, output from a `rake` command.
+        # @return [String, nil] Line from input that matches matcher.
         def self.first_match_from(report_lines)
           Array(report_lines).grep(_matcher).first
         end
 
+        # Returns first capture from Regexp match data.
+        #
+        # @param match_data [MatchData] object instance
+        # @return [Object, nil] First capture from input data; nil if none.
         def self._first_capture(match_data)
           match_data.captures.first
         end
 
+        # Actual Regexp instance used for matching Reek input.
+        #
+        # @return [Regexp] Matches total-warning line for Reek output.
         def self._matcher
           /^(\d+) total warning/
         end
@@ -25,12 +48,21 @@ module Rerake
 
       attr_reader :counts
 
+      # Initialises a Reek output parser. Initialises warning count to 0.
+      #
+      # @param report_lines [Array] Captured output from a 'rake' command.
+      # @return [Parser::Reek] self
       def initialize(report_lines)
         @report_lines = report_lines
         @counts = { warnings: 0 }
         self
       end
 
+      # Parse Reek report line in output to acquire count of detected errors.
+      #
+      # Leaves count unchanged (at zero) if Reek report total line not found.
+      #
+      # @return [Parser::Reek] self
       def parse
         return self unless detail_line
         assign_counts
@@ -39,14 +71,24 @@ module Rerake
 
       private
 
+      # [Array] Input lines passed in to `#initialize`.
       attr_reader :report_lines
 
+      # Extracts total-warning count from detail line, saving in ivar.
+      #
+      # @return [Parser::Reek] self
       def assign_counts
         @counts[:warnings] = Internals.count_from detail_line
+        self
       end
 
+      # Searches `report_lines` for line matching Reek summary-detail line.
+      #
+      # Memoises in "private" instance variable on first call.
+      #
+      # @return [String, nil] First Reek summary-detail line; nil if none. 
       def detail_line
-        @detail_line ||= Internals.first_match_from(report_lines)
+        @_detail_line ||= Internals.first_match_from(report_lines)
       end
     end # class Rerake::Parser::Reek
   end

--- a/lib/rerake/parser/rubo_cop.rb
+++ b/lib/rerake/parser/rubo_cop.rb
@@ -1,0 +1,60 @@
+
+module Rerake
+  module Parser
+    # Parses RuboCop statistics reported with test output.
+    class RuboCop
+      # Internal methods not affecting or depending on instance state.
+      module Internals
+        def self.matcher
+          /(\d+) files inspected, (\S+) offenses detected/
+        end
+      end
+      private_constant :Internals
+
+      attr_reader :counts
+
+      def initialize(report_lines)
+        @report_lines = report_lines
+        @counts = {}
+        indexes.each { |index| @counts[index] = 0 }
+        self
+      end
+
+      def parse
+        return self unless detail_line
+        assign_counts
+        self
+      end
+
+      private
+
+      attr_reader :report_lines
+
+      def assign_counts
+        values.each_with_index do |value, index|
+          @counts[indexes[index]] = value
+        end
+      end
+
+      def captures
+        detail_line.match(Internals.matcher).captures
+      end
+
+      def detail_line
+        @detail_line ||= Array(report_lines).grep(Internals.matcher).first
+      end
+
+      def detail_line_part_strings
+        ['files', 'offenses']
+      end
+
+      def indexes
+        detail_line_part_strings.map(&:to_sym)
+      end
+
+      def values
+        captures.map(&:to_i)
+      end
+    end # class Rerake::Parser::RuboCop
+  end
+end

--- a/lib/rerake/parser/rubo_cop.rb
+++ b/lib/rerake/parser/rubo_cop.rb
@@ -5,6 +5,10 @@ module Rerake
     class RuboCop
       # Internal methods not affecting or depending on instance state.
       module Internals
+        def self.first_match_from(report_lines)
+          Array(report_lines).grep(matcher).first
+        end
+
         def self.matcher
           /(\d+) files inspected, (\S+) offenses detected/
         end
@@ -41,7 +45,7 @@ module Rerake
       end
 
       def detail_line
-        @detail_line ||= Array(report_lines).grep(Internals.matcher).first
+        @detail_line ||= Internals.first_match_from(report_lines)
       end
 
       def detail_line_part_strings

--- a/lib/rerake/parser/simple_cov.rb
+++ b/lib/rerake/parser/simple_cov.rb
@@ -1,0 +1,65 @@
+
+module Rerake
+  module Parser
+    # Parses SimpleCov statistics reported with test output.
+    class SimpleCov
+      # Internal methods not affecting or depending on instance state.
+      module Internals
+        def self.call_converter(pair)
+          pair.first.send pair.last
+        end
+
+        def self.matcher
+          pattern_str = 'Coverage report .+?' \
+              ' (\d+) \/ (\d+) LOC' \
+              ' \((\d+?\.\d+)%\) covered\.'
+          Regexp.new pattern_str
+        end
+      end
+      private_constant :Internals
+
+      attr_reader :counts
+
+      def initialize(report_lines)
+        @report_lines = report_lines
+        @counts = {}
+        indexes.each { |index| @counts[index] = 0 }
+        self
+      end
+
+      def parse
+        return self unless detail_line
+        assign_counts
+        self
+      end
+
+      private
+
+      attr_reader :report_lines
+
+      def assign_counts
+        values.each_with_index do |value, index|
+          @counts[indexes[index]] = value
+        end
+      end
+
+      def detail_line
+        @detail_line ||= Array(report_lines).grep(Internals.matcher).first
+      end
+
+      def detail_line_part_strings
+        ['covered_lines', 'lines', 'coverage']
+      end
+
+      def indexes
+        detail_line_part_strings.map(&:to_sym)
+      end
+
+      def values
+        captures = detail_line.match(Internals.matcher).captures
+        conversions = [:to_f, :to_f, :to_i]
+        captures.zip(conversions).map { |pair| Internals.call_converter pair }
+      end
+    end # class Rerake::Parser::SimpleCov
+  end
+end

--- a/lib/rerake/parser/simple_cov.rb
+++ b/lib/rerake/parser/simple_cov.rb
@@ -9,6 +9,10 @@ module Rerake
           pair.first.send pair.last
         end
 
+        def self.first_match(lines)
+          lines.grep(matcher).first
+        end
+
         def self.matcher
           pattern_str = 'Coverage report .+?' \
               ' (\d+) \/ (\d+) LOC' \
@@ -43,8 +47,17 @@ module Rerake
         end
       end
 
+      def captures
+        detail_line.match(Internals.matcher).captures
+      end
+
+      def captures_and_conversions
+        conversions = [:to_f, :to_f, :to_i]
+        captures.zip(conversions)
+      end
+
       def detail_line
-        @detail_line ||= Array(report_lines).grep(Internals.matcher).first
+        @detail_line ||= Internals.first_match Array(report_lines)
       end
 
       def detail_line_part_strings
@@ -56,9 +69,7 @@ module Rerake
       end
 
       def values
-        captures = detail_line.match(Internals.matcher).captures
-        conversions = [:to_f, :to_f, :to_i]
-        captures.zip(conversions).map { |pair| Internals.call_converter pair }
+        captures_and_conversions.map { |pair| Internals.call_converter pair }
       end
     end # class Rerake::Parser::SimpleCov
   end

--- a/rerake.gemspec
+++ b/rerake.gemspec
@@ -36,12 +36,12 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rake', '~> 10.0'
 
   spec.add_development_dependency 'minitest-matchers', '~> 1.4'
-  spec.add_development_dependency 'minitest-reporters', '~> 1.0'
+  spec.add_development_dependency 'minitest-reporters', '~> 1.1'
   spec.add_development_dependency 'coveralls', '~> 0.8'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
+  spec.add_development_dependency 'inch', '~> 0.6'
   # spec.add_development_dependency 'pry-byebug', '~> 3.2'
   # spec.add_development_dependency 'awesome_print', '~> 1.6'
-  # spec.add_development_dependency 'inch', '~> 0.6'
 
   # Why are these *development* dependencies when the whole point of this Gem is
   # to parse their output from running Rake (on another app)? Because it's not
@@ -50,7 +50,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.7'
   spec.add_development_dependency 'flay', '~> 2.6'
   spec.add_development_dependency 'flog', '~> 4.3'
-  spec.add_development_dependency 'reek', '~> 3.1'
+  spec.add_development_dependency 'reek', '~> 3.4'
   spec.add_development_dependency 'rubocop', '~> 0.32'
   spec.add_development_dependency 'simplecov', '~> 0.10'
 end

--- a/rerake.gemspec
+++ b/rerake.gemspec
@@ -32,23 +32,25 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.10'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_dependency 'bundler', '~> 1.10'
+  spec.add_dependency 'rake', '~> 10.0'
+
   spec.add_development_dependency 'minitest-matchers', '~> 1.4'
   spec.add_development_dependency 'minitest-reporters', '~> 1.0'
   spec.add_development_dependency 'coveralls', '~> 0.8'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
-  spec.add_development_dependency 'pry-byebug', '~> 3.2'
+  # spec.add_development_dependency 'pry-byebug', '~> 3.2'
+  # spec.add_development_dependency 'awesome_print', '~> 1.6'
+  # spec.add_development_dependency 'inch', '~> 0.6'
+
   # Why are these *development* dependencies when the whole point of this Gem is
   # to parse their output from running Rake (on another app)? Because it's not
   # an error for any of these not to be used by that other app, even though we
   # use them ourselves.
   spec.add_development_dependency 'minitest', '~> 5.7'
-  spec.add_development_dependency 'cane', '~> 2.6'
   spec.add_development_dependency 'flay', '~> 2.6'
   spec.add_development_dependency 'flog', '~> 4.3'
   spec.add_development_dependency 'reek', '~> 3.1'
   spec.add_development_dependency 'rubocop', '~> 0.32'
   spec.add_development_dependency 'simplecov', '~> 0.10'
-  # spec.add_development_dependency 'inch', '~> 0.6'
 end

--- a/rerake.gemspec
+++ b/rerake.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest-reporters', '~> 1.0'
   spec.add_development_dependency 'coveralls', '~> 0.8'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
+  spec.add_development_dependency 'pry-byebug', '~> 3.2'
   # Why are these *development* dependencies when the whole point of this Gem is
   # to parse their output from running Rake (on another app)? Because it's not
   # an error for any of these not to be used by that other app, even though we

--- a/test/rerake/command_output_test.rb
+++ b/test/rerake/command_output_test.rb
@@ -1,0 +1,43 @@
+
+require 'test_helper'
+
+require 'rerake/command_output'
+
+describe 'Rerake::CommandOutput' do
+  let(:described_class) { Rerake::CommandOutput }
+
+  describe 'when a successful shell command is specified to #initialize' do
+    let(:obj) { described_class.new 'ls' }
+
+    it 'returns a status indicating exit code of 0' do
+      expect(obj.status).must_equal 0
+    end
+
+    it 'indicates that there were no errors' do
+      expect(obj.errors).must_be_empty
+    end
+
+    it 'produces the expected output' do
+      output = obj.output
+      expect(output).must_be_instance_of Array
+      expect(output).wont_be_empty
+      expect(output.reject { |s| s.instance_of? String }).must_be_empty
+    end
+  end # describe 'when a successful shell command is specified to #initialize'
+
+  describe 'when an unsuccessful command is specified to #initialize' do
+    let(:obj) { described_class.new 'ls /foo/bar/this/does/not/exist' }
+
+    it 'returns a status indicating a nonzero exit code' do
+      expect(obj.status).wont_equal 0
+    end
+
+    it 'indicates that there were errors' do
+      expect(obj.errors).wont_be_empty
+    end
+
+    it 'produces the expected output' do
+      expect(obj.output).must_be_empty
+    end
+  end # describe 'when an unsuccessful command is specified to #initialize'
+end

--- a/test/rerake/parser/flay_test.rb
+++ b/test/rerake/parser/flay_test.rb
@@ -1,0 +1,64 @@
+
+require 'test_helper'
+
+require 'rerake/parser/flay'
+
+describe 'Rerake::Parser::Flay' do
+  let(:described_class) { ::Rerake::Parser::Flay }
+  let(:obj) { described_class.new input }
+
+  describe 'is initialised to a known state, with zero values for' do
+    let(:input) { :whatever_as_long_as_parse_not_called }
+    let(:counts) { obj.counts }
+
+    it 'all counts' do
+      expect(counts.values.detect(&:nonzero?)).must_be_nil
+    end
+  end # describe 'is initialised to a known state, with zero values for'
+
+  describe 'has a #parse method that' do
+    let(:obj) { described_class.new(input).parse }
+
+    describe 'when given valid Flay input' do
+      describe 'which reports no problems' do
+        describe 'assigns correct values for' do
+          let(:counts) { { total_score: 0 } }
+
+          let(:input) do
+            "blah blah blah\n" \
+            "we don't care about anything not matching Flay format\n" \
+            "Total score (lower is better) = #{counts[:total_score]}\n" \
+            "more junk may well appear afterwards\n"
+              .split("\n")
+          end
+
+          it 'total_score' do
+            expect(obj.counts[:total_score]).must_equal counts[:total_score]
+          end
+        end # describe 'assigns correct values for'
+      end # describe 'which reports no problems'
+
+      describe 'which reports detected problems' do
+        describe 'assigns correct values for' do
+          let(:counts) { { total_score: 38 } }
+
+          let(:input) do
+            "blah blah blah\n" \
+            "we don't care about anything not matching Flay format\n" \
+            "Total score (lower is better) = #{counts[:total_score]}\n" \
+            '1) Similar code found in :iter ' \
+            "(mass = #{counts[:total_score]})\n" \
+            "  path/to/some/file.rb:9\n" \
+            "  path/to/some/other_file.rb:7\n" \
+            "more junk may well appear afterwards\n"
+              .split("\n")
+          end
+
+          it 'total_score' do
+            expect(obj.counts[:total_score]).must_equal counts[:total_score]
+          end
+        end # describe 'assigns correct values for'
+      end # describe 'which reports detected problems'
+    end # describe 'when given valid Flay input'
+  end # describe 'has a #parse method that'
+end # describe 'Rerake::Parser::Flay'

--- a/test/rerake/parser/flog_test.rb
+++ b/test/rerake/parser/flog_test.rb
@@ -1,0 +1,52 @@
+
+require 'test_helper'
+
+require 'rerake/parser/flog'
+
+describe 'Rerake::Parser::Flog' do
+  let(:described_class) { ::Rerake::Parser::Flog }
+  let(:obj) { described_class.new input }
+
+  describe 'is initialised to a known state, with zero values for' do
+    let(:input) { :whatever_as_long_as_parse_not_called }
+    let(:counts) { obj.counts }
+
+    it 'all counts' do
+      expect(counts.values.detect(&:nonzero?)).must_be_nil
+    end
+  end # describe 'is initialised to a known state, with zero values for'
+
+  describe 'has a #parse method that' do
+    let(:obj) { described_class.new(input).parse }
+
+    describe 'when given valid Flog input' do
+      describe 'assigns correct values for' do
+        let(:counts) do
+          {
+            total: 160.1,
+            method_average: 4.6,
+            max_score: 8.6,
+            max_name: 'Foo::Bar::Baz#values'
+          }
+        end
+
+        let(:input) do
+          "blah blah blah\n" \
+          "we don't care about anything not matching Flog format\n" \
+          "Total score (lower is better) = 0\n" \
+          "   160.1: flog total\n" \
+          "     4.6: flog/method average\n\n" \
+          "     8.6: Foo::Bar::Baz#values lib/foo/bar/baz.rb:58\n" \
+          "     7.9: Foo::Bar::Quux#matcher lib/foo/bar/quux.rb:35\n" \
+          "     6.7: Foo::Bar::Quux#detail_line lib/foo/bar/quux.rb:42\n" \
+          "more junk may well appear afterwards\n"
+            .split("\n")
+        end
+
+        it 'counts' do
+          expect(obj.counts.to_h).must_equal counts
+        end
+      end # describe 'assigns correct values for'
+    end # describe 'when given valid Flog input'
+  end # describe 'has a #parse method that'
+end # describe 'Rerake::Parser::Flog'

--- a/test/rerake/parser/mini_test_test.rb
+++ b/test/rerake/parser/mini_test_test.rb
@@ -1,8 +1,6 @@
 
 require 'test_helper'
 
-require 'pry-byebug'
-
 require 'rerake/parser/mini_test'
 
 describe 'Rerake::Parser::MiniTest' do
@@ -61,6 +59,6 @@ describe 'Rerake::Parser::MiniTest' do
       it 'maintains zero values for all counts' do
         expect(obj.counts.values.detect(&:nonzero?)).must_be_nil
       end
-    end
+    end # describe 'when given invalid MiniTest output'
   end # describe 'has a #parse method that'
 end # describe 'Rerake::Parser::MiniTest'

--- a/test/rerake/parser/mini_test_test.rb
+++ b/test/rerake/parser/mini_test_test.rb
@@ -1,0 +1,66 @@
+
+require 'test_helper'
+
+require 'pry-byebug'
+
+require 'rerake/parser/mini_test'
+
+describe 'Rerake::Parser::MiniTest' do
+  let(:described_class) { ::Rerake::Parser::MiniTest }
+  let(:obj) { described_class.new input }
+
+  describe 'is initialised to a known state, with zero values for' do
+    let(:input) { :whatever_as_long_as_parse_not_called }
+    let(:counts) { obj.counts }
+
+    it 'all counts' do
+      expect(counts.values.detect(&:nonzero?)).must_be_nil
+    end
+  end # describe 'is initialised to a known state, with zero values for'
+
+  describe 'has a #parse method that' do
+    let(:obj) { described_class.new(input).parse }
+
+    describe 'when given valid MiniTest output' do
+      describe 'assigns correct values for' do
+        # MiniTest won't let us use variables like 'assertions'. :disappointed:
+        let(:counts) do
+          {
+            assertions: 24,
+            errors: 2,
+            failures: 3,
+            skips: 4,
+            tests: 16
+          }
+        end
+        let(:input) do
+          "Other junk might be before the important line\n" \
+          "Even more junk might be before the important line\n" \
+          "Output might include terminal colour control sequences, or not\n" \
+          "\e[32m#{counts[:tests]} tests, " \
+          "#{counts[:assertions]} assertions, " \
+          "#{counts[:failures]} failures, " \
+          "#{counts[:errors]} errors, " \
+          "#{counts[:skips]} skips" \
+          "\e[0m\n" \
+          "More junk might be after it; we shouldn't care.\n"
+            .split("\n")
+        end
+
+        [:assertions, :errors, :failures, :skips, :tests].each do |which|
+          it "#{which}" do
+            expect(obj.counts[which]).must_equal counts[which]
+          end
+        end
+      end # describe 'assigns correct values for'
+    end # describe 'when given valid MiniTest output'
+
+    describe 'when given invalid MiniTest output' do
+      let(:input) { 'this is invalid MiniTest output. deal with it, buddy.' }
+
+      it 'maintains zero values for all counts' do
+        expect(obj.counts.values.detect(&:nonzero?)).must_be_nil
+      end
+    end
+  end # describe 'has a #parse method that'
+end # describe 'Rerake::Parser::MiniTest'

--- a/test/rerake/parser/mini_test_test/counts_test.rb
+++ b/test/rerake/parser/mini_test_test/counts_test.rb
@@ -1,0 +1,29 @@
+
+require 'test_helper'
+
+require 'rerake/parser/mini_test/counts'
+
+describe 'Rerake::Parser::MiniTest::Counts' do
+  let(:described_class) { Rerake::Parser::MiniTest::Counts }
+  let(:obj) { described_class.new keys }
+  let(:keys) { [:foo, :bar, :baz] }
+
+  it 'can be initialised from an array of symbols' do
+    expect { described_class.new([:foo, :bar, :baz]) }.must_be_silent
+  end
+
+  describe 'has an #assign_from method that' do
+    it 'assigns to the members as defined, in order' do
+      obj = described_class.new([:foo, :bar, :baz])
+      obj.assign_from %w(1 4 2)
+      expect(obj[:foo]).must_equal 1
+      expect(obj[:bar]).must_equal 4
+      expect(obj[:baz]).must_equal 2
+    end
+  end # describe 'has an #assign_from method that'
+
+  it 'has a #to_s method that renders as it would a Hash' do
+    hash = obj.to_hash
+    expect(obj.to_s).must_equal hash.to_s
+  end
+end # describe 'Rerake::Parser::MiniTest::Counts'

--- a/test/rerake/parser/reek_test.rb
+++ b/test/rerake/parser/reek_test.rb
@@ -1,0 +1,61 @@
+
+require 'test_helper'
+
+require 'rerake/parser/reek'
+
+describe 'Rerake::Parser::Reek' do
+  let(:described_class) { ::Rerake::Parser::Reek }
+  let(:obj) { described_class.new input }
+
+  describe 'is initialised to a known state, with zero values for' do
+    let(:input) { :whatever_as_long_as_parse_not_called }
+    let(:counts) { obj.counts }
+
+    it 'all counts' do
+      expect(counts.to_h.values.detect(&:nonzero?)).must_be_nil
+    end
+  end # describe 'is initialised to a known state, with zero values for'
+
+  describe 'has a #parse method that' do
+    let(:obj) { described_class.new(input).parse }
+
+    describe 'when given valid Reek input' do
+      describe 'when no warnings are generated' do
+        describe 'assigns correct values for' do
+          let(:counts) { { warnings: 0 } }
+          let(:input) do
+            "blah blah blah\n" \
+            "we don't care about anything not matching Reek format\n" \
+            "0 total warnings\n" \
+            "more junk may well appear afterwards\n"
+              .split("\n")
+          end
+
+          it 'counts' do
+            expect(obj.counts.to_h).must_equal counts
+          end
+        end # describe 'assigns correct values for'
+      end # describe 'when no warnings are generated'
+
+      describe 'when warnings are generated' do
+        describe 'assigns correct values to' do
+          let(:counts) { { warnings: 1 } }
+          let(:input) do
+            "blah blah blah\n" \
+            "we don't care about anything not matching Reek format\n" \
+            "app/foo/bar.rb -- 1 warning:\n" \
+            "  app/foo/bar.rb:22: Foo::Bar#initialize doesn't depend on" \
+            " instance state (UtilityFunction)\n" \
+            "1 total warning\n" \
+            "more junk may well appear afterwards\n"
+              .split("\n")
+          end
+
+          it 'counts' do
+            expect(obj.counts.to_h).must_equal counts
+          end
+        end # describe 'assigns correct values to'
+      end # describe 'when warnings are generated'
+    end # describe 'when given valid Reek input'
+  end # describe 'has a #parse method that'
+end # describe 'Rerake::Parser::Reek'

--- a/test/rerake/parser/rubo_cop_test.rb
+++ b/test/rerake/parser/rubo_cop_test.rb
@@ -1,0 +1,81 @@
+
+require 'test_helper'
+
+require 'rerake/parser/rubo_cop'
+
+describe 'Rerake::Parser::RuboCop' do
+  let(:described_class) { ::Rerake::Parser::RuboCop }
+  let(:obj) { described_class.new input }
+
+  describe 'is initialised to a known state, with zero values for' do
+    let(:input) { :whatever_as_long_as_parse_not_called }
+    let(:counts) { obj.counts }
+
+    it 'all counts' do
+      expect(counts.values.detect(&:nonzero?)).must_be_nil
+    end
+  end # describe 'is initialised to a known state, with zero values for'
+
+  describe 'has a #parse method that' do
+    let(:obj) { described_class.new(input).parse }
+
+    describe 'when given valid RuboCop input' do
+      describe 'which reports detected offenses' do
+        describe 'assigns correct values for' do
+          let(:counts) do
+            {
+              files:    20,
+              offenses: 3
+            }
+          end
+          let(:input) do
+            "blah blah blah\n" \
+            "we don't care about anything not matching RuboCop format\n" \
+            "#{counts[:files]} files inspected," \
+            " #{counts[:offenses]} offenses detected\n" \
+            "more junk may well appear afterwards\n"
+              .split("\n")
+          end
+
+          [:files, :offenses].each do |which|
+            it "#{which}" do
+              expect(obj.counts[which]).must_equal counts[which]
+            end
+          end
+        end # describe 'assigns correct values for'
+      end # describe 'which reports detected offenses'
+
+      describe 'which reports no detected offenses' do
+        describe 'assigns correct values for' do
+          let(:counts) do
+            {
+              files:    7,
+              offenses: 0
+            }
+          end
+          let(:input) do
+            "blah blah blah\n" \
+            "we don't care about anything not matching RuboCop format\n" \
+            "#{counts[:files]} files inspected, no offenses detected\n" \
+            "more junk may well appear afterwards\n"
+              .split("\n")
+          end
+
+          [:files, :offenses].each do |which|
+            it "#{which}" do
+              expect(obj.counts[which]).must_equal counts[which]
+            end
+          end
+        end # describe 'assigns correct values for'
+      end # describe 'which reports no detected offenses'
+    end # describe 'when given valid RuboCop input'
+
+    describe 'when given invalid RuboCop input' do
+      let(:input) { 'this is invalid RuboCop output. deal with it, buddy.' }
+
+      it 'maintains zero values for all counts' do
+        expect(obj.counts.values.detect(&:nonzero?)).must_be_nil
+      end
+    end # describe 'when given invalid RuboCop input'
+  end # describe 'has a #parse method that'
+end # describe 'Rerake::Parser::RuboCop'

--- a/test/rerake/parser/simple_cov_test.rb
+++ b/test/rerake/parser/simple_cov_test.rb
@@ -1,0 +1,57 @@
+
+require 'test_helper'
+
+require 'rerake/parser/simple_cov'
+
+describe 'Rerake::Parser::SimpleCov' do
+  let(:described_class) { ::Rerake::Parser::SimpleCov }
+  let(:obj) { described_class.new input }
+
+  describe 'is initialised to a known state, with zero values for' do
+    let(:input) { :whatever_as_long_as_parse_not_called }
+    let(:counts) { obj.counts }
+
+    it 'all counts' do
+      expect(counts.values.detect(&:nonzero?)).must_be_nil
+    end
+  end # describe 'is initialised to a known state, with zero values for'
+
+  describe 'has a #parse method that' do
+    let(:obj) { described_class.new(input).parse }
+
+    describe 'when given valid SimpleCov input' do
+      describe 'assigns correct values for' do
+        let(:counts) do
+          {
+            covered_lines: 45,
+            lines:         50,
+            coverage:      90.0
+          }
+        end
+        let(:input) do
+          "blah blah blah\n" \
+          "we don't care about anything not matching SimpleCov format\n" \
+          'Coverage report generated for Unit Tests to /some/dir. ' \
+          "#{counts[:covered_lines]} / #{counts[:lines]} LOC " \
+          "(#{counts[:coverage]}%) covered.\n" \
+          "more junk may well appear afterwards\n"
+            .split("\n")
+        end
+
+        [:covered_lines, :lines, :coverage].each do |which|
+          it "#{which}" do
+            expect(obj.counts[which]).must_equal counts[which]
+          end
+        end
+      end # describe 'assigns correct values for'
+    end # describe 'when given valid SimpleCov input'
+
+    describe 'when given invalid SimpleCov output' do
+      let(:input) { 'this is invalid SimpleCov output. deal with it, buddy.' }
+
+      it 'maintains zero values for all counts' do
+        expect(obj.counts.values.detect(&:nonzero?)).must_be_nil
+      end
+    end # describe 'when given invalid SimpleCov output'
+  end # describe 'has a #parse method that'
+end # describe 'Rerake::Parser::SimpleCov'

--- a/test/rerake_test.rb
+++ b/test/rerake_test.rb
@@ -2,9 +2,30 @@
 require 'test_helper'
 
 describe 'Rerake.call' do
-  it 'will eventually do something useful' do
-    skip 'It does nothing yet.'
+  let(:cmd) { Rerake.call }
+
+  before do
+    ENV['RERAKE_COMMAND'] = 'find lib -name \*.rb'
   end
+
+  it 'returns a Rerake::CommandOutput instance' do
+    expect(cmd).must_be_instance_of Rerake::CommandOutput
+  end
+
+  describe 'returns a Rerake::CommandOutput instance with' do
+    it 'a status code of 0' do
+      expect(cmd.status).must_equal 0
+    end
+
+    it 'no errors indicated' do
+      expect(cmd.errors).must_be_empty
+    end
+
+    it 'expected output' do
+      expected = Dir.glob('lib/**/*.rb')
+      expect(cmd.output).must_equal expected
+    end
+  end # describe 'returns a Rerake::CommandOutput instance with'
 end
 
 describe 'Rerake::VERSION' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,7 @@ require 'simplecov'
 require 'minitest/autorun'
 require 'codeclimate-test-reporter'
 require 'coveralls'
+require 'pry-byebug'
 
 SimpleCov.start do
   add_filter '/vendor/'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,6 @@ require 'simplecov'
 require 'minitest/autorun'
 require 'codeclimate-test-reporter'
 require 'coveralls'
-require 'pry-byebug'
 
 SimpleCov.start do
   add_filter '/vendor/'
@@ -21,5 +20,4 @@ Coveralls.wear! if ENV['COVERALLS_REPO_TOKEN']
 
 require 'minitest/reporters'
 Minitest::Reporters.use! [Minitest::Reporters::DefaultReporter.new(
-  color: true, detailed_skip: true, fast_fail: true)
-                         ]
+  color: true, detailed_skip: true, fast_fail: true)]


### PR DESCRIPTION
This will implement parsers for each of the tools used by the _initial version of_ Rerake. These include:
- [x] MiniTest (in the form of `MiniTest::Spec`);
- [x] SimpleCov;
- [x] RuboCop;
- [x] Flay;
- [x] Flog;
- [ ] Reek; and
- [ ] Cane.

Once these are done, we can then bolt on a CLI and we have a useable tool again. :clap:
